### PR TITLE
A template parameter on model coefficients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project (libthermo)
 option(BUILD_TESTS "Enable C++ tests for libthermo" OFF)
 option(BUILD_BENCHS "Enable C++ benchmarks for libthermo" OFF)
 option(BUILD_PY "Build Python bindings of libthermo" OFF)
+option(LIBTHERMO_USE_FMA "Use FMA instructions in libthermo" ON)
 option(LIBTHERMO_USE_XTENSOR "Enable C++ xtensor for libthermo" OFF)
 
 # Set installation directories (CMAKE_INSTALL_INCLUDEDIR, CMAKE_INSTALL_BINDIR, CMAKE_INSTALL_LIBDIR)
@@ -57,6 +58,19 @@ target_include_directories(
 
 find_package(Boost COMPONENTS math)
 
+if(WIN32 AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"))
+    target_compile_options(libthermo INTERFACE /arch:AVX2)
+elseif(UNIX AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+    target_compile_options(libthermo INTERFACE -mfma)
+endif()
+
+if (LIBTHERMO_USE_FMA)
+    target_compile_definitions(libthermo
+        INTERFACE
+            LIBTHERMO_USE_FMA
+    )
+endif()
+
 if (LIBTHERMO_USE_XTENSOR)
     find_package(xtensor REQUIRED)
     target_compile_definitions(libthermo
@@ -64,7 +78,7 @@ if (LIBTHERMO_USE_XTENSOR)
             LIBTHERMO_USE_XTENSOR
     )
     target_link_libraries(libthermo INTERFACE xtensor)
-endif ()
+endif()
 
 target_link_libraries(libthermo
     INTERFACE           

--- a/benchs/CMakeLists.txt
+++ b/benchs/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(thermo_benchs_srcs main.cc)
 
 find_package(nlohmann_json 3.11.2 REQUIRED)
+find_package(TBB REQUIRED)
 
 add_executable(thermo_benchs ${thermo_benchs_srcs})
 
 target_compile_options(thermo_benchs PUBLIC "-march=native")
 
 add_definitions(-DXTENSOR_TBB_THRESHOLD=5000)
+add_definitions(-DXTENSOR_USE_TBB)
+add_definitions(-DXTENSOR_USE_XSIMD)
 
 target_link_libraries(thermo_benchs
     PUBLIC
@@ -15,4 +18,7 @@ target_link_libraries(thermo_benchs
     PRIVATE
         nlohmann_json::nlohmann_json
 )
+
+target_compile_features(thermo_benchs INTERFACE cxx_std_20)
+
 install(TARGETS thermo_benchs DESTINATION ${BIN_DIR})

--- a/benchs/main.cc
+++ b/benchs/main.cc
@@ -22,10 +22,7 @@ namespace fs = std::filesystem;
 
 namespace thermo
 {
-    nlohmann::json timeit(std::function<void()> f,
-                          std::size_t size,
-                          unsigned long repeat,
-                          unsigned long number)
+    nlohmann::json timeit(std::function<void()> f, std::size_t size, unsigned long repeat, unsigned long number)
     {
         xt::xtensor<double, 1>::shape_type times_shape = { number };
         xt::xtensor<double, 1> times(times_shape, 1.);
@@ -35,8 +32,7 @@ namespace thermo
             auto t1 = std::chrono::high_resolution_clock::now();
             f();
             auto t2 = std::chrono::high_resolution_clock::now();
-            auto t = static_cast<double>(
-                         std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count())
+            auto t = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count())
                      / static_cast<double>(repeat * size);
 
             times[i] = t;
@@ -222,8 +218,7 @@ namespace thermo
             auto t1 = std::chrono::high_resolution_clock::now();
             f(ntimes);
             auto t2 = std::chrono::high_resolution_clock::now();
-            return static_cast<double>(
-                       std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count())
+            return static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count())
                    / static_cast<double>(ntimes * size);
         };
 
@@ -237,7 +232,7 @@ namespace thermo
         std::cout << "t_f_phi -> " << timeit(bench_t_from_phi, ntimes) << " ns" << std::endl;
         std::cout << "t_f_pr -> " << timeit(bench_t_from_pr, ntimes) << " ns" << std::endl;
         std::cout << "eff_poly -> " << timeit(bench_eff_poly, ntimes) << " ns" << std::endl;
-        std::cout << "mach_f_wqa -> " << timeit(bench_mach_f_wqa, ntimes) << " ns" << std::endl;
+        std::cout << "mach_f_wqa -> " << timeit(bench_mach_f_wqa, ntimes / 2) << " ns" << std::endl;
         std::cout << "Pout -> " << timeit(bench_pout, ntimes) << " ns" << std::endl;
     }
 
@@ -345,8 +340,8 @@ namespace thermo
         nlohmann::json j;
         j["N"] = size;
 
-#define TIME_F(NAME)                                                                               \
-    j[#NAME] = timeit(bench_##NAME, size, repeat, number);                                         \
+#define TIME_F(NAME)                                                                                                   \
+    j[#NAME] = timeit(bench_##NAME, size, repeat, number);                                                             \
     std::cout << #NAME << " --> " << j[#NAME] << " ns";
 
 
@@ -360,19 +355,19 @@ namespace thermo
     }
 
 #ifdef LIBTHERMO_USE_XTENSOR
-    template <class G>
+    template <class G, class D = typename std::remove_reference_t<G>::value_t>
     void benchmark_vector(G&& gas, std::size_t size, unsigned long repeat, unsigned number)
     {
-        xt::xtensor<double, 1>::shape_type shape = { size };
-        xt::xtensor<double, 1> res(shape, 1.);
+        typename xt::xtensor<D, 1>::shape_type shape = { size };
+        xt::xtensor<D, 1> res(shape, 1.);
 
-        xt::xtensor<double, 1> t1(shape, 273.15);
-        xt::xtensor<double, 1> t2(shape, 350.);
+        xt::xtensor<D, 1> t1(shape, 273.15);
+        xt::xtensor<D, 1> t2(shape, 350.);
 
-        xt::xtensor<double, 1> p1(shape, 101325.);
-        xt::xtensor<double, 1> p2(shape, 500000.);
+        xt::xtensor<D, 1> p1(shape, 101325.);
+        xt::xtensor<D, 1> p2(shape, 500000.);
 
-        xt::xtensor<double, 1> eff(shape, 0.82);
+        xt::xtensor<D, 1> eff(shape, 0.82);
 
         auto bench_cp = [&]() -> void
         {
@@ -505,7 +500,7 @@ main()
     }
 
     {
-        PolyGas gas(PolyGasProps<8>({ 0., 0., 0., 0., 0., 0., 0., 1004.4 }, 0., 287.05287));
+        PolyGas gas(PolyGasProps<double, 8>({ 0., 0., 0., 0., 0., 0., 0., 1004.4 }, 0., 287.05287));
 
         std::cout << "\n"
                   << "Reference values" << std::endl;
@@ -516,8 +511,7 @@ main()
         std::cout << "pr -> " << gas.pr(Tref, 450., 0.82) << std::endl;
         std::cout << "t_f_h -> " << gas.t_f_h(gas.h(Tref), 1e-8) << std::endl;
         std::cout << "t_f_phi -> " << gas.t_f_phi(gas.phi(Tref), 1e-8) << std::endl;
-        std::cout << "t_f_pr -> " << gas.t_f_pr(gas.pr(Tref, 450., 0.82), Tref, 0.82, 1e-8)
-                  << std::endl;
+        std::cout << "t_f_pr -> " << gas.t_f_pr(gas.pr(Tref, 450., 0.82), Tref, 0.82, 1e-8) << std::endl;
 
         std::cout << "\nSingle value tests" << std::endl;
         benchmark_single_value(gas, 100000, 50);
@@ -528,7 +522,11 @@ main()
 
 #ifdef LIBTHERMO_USE_XTENSOR
         std::cout << "\nVector tests 1M" << std::endl;
-        benchmark_vector(gas, 1000000, 1000, 10);
+        benchmark_vector(gas, 1000000, 10, 10);
+
+        PolyGas gas_float(PolyGasProps<float, 8>({ 0., 0., 0., 0., 0., 0., 0., 1004.4 }, 0., 287.05287));
+        std::cout << "\nVector tests 1M float" << std::endl;
+        benchmark_vector(gas_float, 1000000, 10, 10);
 #endif
     }
     // std::cout << XSIMD_X86_INSTR_SET << std::endl;

--- a/benchs/main.cc
+++ b/benchs/main.cc
@@ -27,7 +27,7 @@ namespace thermo
         xt::xtensor<double, 1>::shape_type times_shape = { number };
         xt::xtensor<double, 1> times(times_shape, 1.);
 
-        for (long i = 0; i < number; ++i)
+        for (std::size_t i = 0; i < number; ++i)
         {
             auto t1 = std::chrono::high_resolution_clock::now();
             f();
@@ -359,19 +359,19 @@ namespace thermo
     void benchmark_vector(G&& gas, std::size_t size, unsigned long repeat, unsigned number)
     {
         typename xt::xtensor<D, 1>::shape_type shape = { size };
-        xt::xtensor<D, 1> res(shape, 1.);
+        xt::xtensor<D, 1> res(shape, D(1.));
 
-        xt::xtensor<D, 1> t1(shape, 273.15);
-        xt::xtensor<D, 1> t2(shape, 350.);
+        xt::xtensor<D, 1> t1(shape, D(273.15));
+        xt::xtensor<D, 1> t2(shape, D(350.));
 
-        xt::xtensor<D, 1> p1(shape, 101325.);
-        xt::xtensor<D, 1> p2(shape, 500000.);
+        xt::xtensor<D, 1> p1(shape, D(101325.));
+        xt::xtensor<D, 1> p2(shape, D(500000.));
 
-        xt::xtensor<D, 1> eff(shape, 0.82);
+        xt::xtensor<D, 1> eff(shape, D(0.82));
 
         auto bench_cp = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.cp(t1);
             };
@@ -379,7 +379,7 @@ namespace thermo
 
         auto bench_gamma = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.gamma(t1);
             };
@@ -387,7 +387,7 @@ namespace thermo
 
         auto bench_h = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.h(t1);
             };
@@ -395,7 +395,7 @@ namespace thermo
 
         auto bench_phi = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.phi(t1);
             };
@@ -415,7 +415,7 @@ namespace thermo
         */
         auto bench_pr = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.pr(t1, t2, eff);
             };
@@ -423,7 +423,7 @@ namespace thermo
 
         auto bench_eff_poly = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.eff_poly(p1, t1, p2, t2);
             };
@@ -431,7 +431,7 @@ namespace thermo
 
         auto bench_pout = [&]() -> void
         {
-            for (long i = 0; i < repeat; i++)
+            for (std::size_t i = 0; i < repeat; i++)
             {
                 xt::noalias(res) = gas.pr(t1, t2, gas.eff_poly(p1, t1, p2, t2)) * p2;
             };

--- a/include/libthermo/detail/ideal_gas_xt_impl.hpp
+++ b/include/libthermo/detail/ideal_gas_xt_impl.hpp
@@ -13,38 +13,44 @@
 
 namespace thermo
 {
+    template <class D>
     template <class T, IS_XTENSOR_>
-    auto IdealGas::gamma(const T& t) const
+    auto IdealGas<D>::gamma(const T& t) const
     {
         return xt::broadcast(m_gamma, t.shape());
     }
 
+    template <class D>
     template <class T, IS_XTENSOR_>
-    auto IdealGas::cp(const T& t) const
+    auto IdealGas<D>::cp(const T& t) const
     {
         return xt::broadcast(m_cp, t.shape());
     }
 
+    template <class D>
     template <class T, IS_XTENSOR_>
-    auto IdealGas::phi(const T& t) const
+    auto IdealGas<D>::phi(const T& t) const
     {
         return m_cp * xt::log(t);
     }
 
+    template <class D>
     template <class T, class E, IS_XTENSOR_>
-    auto IdealGas::pr(const T& t1, const T& t2, const E& eff_poly) const
+    auto IdealGas<D>::pr(const T& t1, const T& t2, const E& eff_poly) const
     {
         return xt::exp(xt::log(t2 / t1) * eff_poly * m_cp / m_r);
     }
 
+    template <class D>
     template <class T, class E, IS_XTENSOR_>
-    auto IdealGas::Tau(const T& p1, const T& p2, const E& eff_poly) const
+    auto IdealGas<D>::Tau(const T& p1, const T& p2, const E& eff_poly) const
     {
         return xt::exp(xt::log(p2 / p1) * m_r / (eff_poly * m_cp));
     }
 
+    template <class D>
     template <class T, IS_XTENSOR_>
-    auto IdealGas::eff_poly(const T& p1, const T& t1, const T& p2, const T& t2) const
+    auto IdealGas<D>::eff_poly(const T& p1, const T& t1, const T& p2, const T& t2) const
     {
         return r() / m_cp * xt::log(p2 / p1) / xt::log(t2 / t1);
     }

--- a/include/libthermo/detail/polyval.hpp
+++ b/include/libthermo/detail/polyval.hpp
@@ -22,7 +22,11 @@ namespace
         static inline auto eval(E&& x, It coeff)
         {
             auto c = coeff++;
+#ifdef LIBTHERMO_USE_FMA
             return std::fma(x, poly_eval<T, D - 1>::eval(x, coeff), *c);
+#else
+            x* poly_eval<T, D - 1>::eval(x, coeff) + *c;
+#endif
         };
 
 #ifdef LIBTHERMO_USE_XTENSOR

--- a/include/libthermo/detail/polyval.hpp
+++ b/include/libthermo/detail/polyval.hpp
@@ -25,7 +25,7 @@ namespace
 #ifdef LIBTHERMO_USE_FMA
             return std::fma(x, poly_eval<T, D - 1>::eval(x, coeff), *c);
 #else
-            x* poly_eval<T, D - 1>::eval(x, coeff) + *c;
+            return x * poly_eval<T, D - 1>::eval(x, coeff) + *c;
 #endif
         };
 

--- a/include/libthermo/poly_gas.hpp
+++ b/include/libthermo/poly_gas.hpp
@@ -305,7 +305,7 @@ namespace thermo
             h1 = h(t);
             x = h_in - h1;
 
-            if (std::abs(x) < tol)
+            if (std::abs(x / h_in) < tol)
             {
                 converged = true;
                 break;
@@ -368,24 +368,21 @@ namespace thermo
         if (wqa < 0. || wqa > wqa_crit)
             throw domain_error();
 
-        auto err_v = [&](double ts) -> double
-        {
+        auto err_v = [&](double ts) -> double {
             ps = pt * pr(tt, ts, 1.);
             v = std::sqrt(2 * (ht - h(ts)));
             return ps / (r_ * ts) * v - wqa;
         };
 
         boost::uintmax_t niter = max_iter;
-        auto res = boost::math::tools::toms748_solve(
-            err_v,
-            ts_crit,
-            tt,
-            [&tol](const auto& a, const auto& b) -> bool
-            {
-                using std::fabs;
-                return fabs(a - b) / (std::min)(fabs(a), fabs(b)) <= tol;
-            },
-            niter);
+        auto res = boost::math::tools::toms748_solve(err_v,
+                                                     ts_crit,
+                                                     tt,
+                                                     [&tol](const auto& a, const auto& b) -> bool {
+                                                         using std::fabs;
+                                                         return fabs(a - b) / (std::min)(fabs(a), fabs(b)) <= tol;
+                                                     },
+                                                     niter);
         ts = res.first;
         ps = pt * pr(tt, ts, 1.);
         v = std::sqrt(2 * (ht - h(ts)));

--- a/pythermo/src/ideal_gas.cpp
+++ b/pythermo/src/ideal_gas.cpp
@@ -13,29 +13,29 @@ using namespace thermo;
 
 namespace pythermo
 {
-    class PyIdealGas : public PyThermoHelper<IdealGas, array_t>
+    class PyIdealGas : public PyThermoHelper<IdealGas<double>, array_t>
     {
     public:
         PyIdealGas(double r, double cp)
-            : PyThermoHelper<IdealGas, array_t>(r, cp)
+            : PyThermoHelper<IdealGas<double>, array_t>(r, cp)
         {
         }
 
         double static_t(const double& t, const double& mach) const
         {
-            return IdealGas::static_t(t, mach);
+            return IdealGas<double>::static_t(t, mach);
         }
         double t_f_h(const double& h) const
         {
-            return IdealGas::t_f_h(h);
+            return IdealGas<double>::t_f_h(h);
         }
         double t_f_phi(const double& phi) const
         {
-            return IdealGas::t_f_phi(phi);
+            return IdealGas<double>::t_f_phi(phi);
         }
         double t_f_pr(const double& pr, const double& t1, const double& eff_poly) const
         {
-            return IdealGas::t_f_pr(pr, t1, eff_poly);
+            return IdealGas<double>::t_f_pr(pr, t1, eff_poly);
         }
     };
 

--- a/pythermo/src/poly_gas.cpp
+++ b/pythermo/src/poly_gas.cpp
@@ -14,14 +14,14 @@ using namespace thermo;
 
 namespace pythermo
 {
-    using PG8 = PolyGas<PolyGasProps<8>>;
+    using PG8 = PolyGas<PolyGasProps<double, 8>>;
 
     class PyPG8 : public PyThermoHelper<PG8, array_t>
     {
     public:
         using PG8::properties;
 
-        PyPG8(const PolyGasProps<8>& props)
+        PyPG8(const PolyGasProps<double, 8>& props)
             : PyThermoHelper<PG8, array_t>(props)
         {
         }
@@ -31,29 +31,31 @@ namespace pythermo
     {
         using namespace py::literals;
 
-        m.def("mix8", &mix<8>, "cps"_a, "h0s"_a, "rs"_a, "weights"_a);
+        m.def("mix8", &mix<double, 8>, "cps"_a, "h0s"_a, "rs"_a, "weights"_a);
 
-        auto polygasprops8
-            = py::class_<PolyGasProps<8>>(m, "PolyGasProps8")
-                  .def(py::init<const std::array<double, 8>&, double, double>(), "cp_coeffs"_a, "h0"_a, "r"_a);
+        auto polygasprops8 = py::class_<PolyGasProps<double, 8>>(m, "PolyGasProps8")
+                                 .def(py::init<const std::array<double, 8>&, const double&, const double&>(),
+                                      "cp_coeffs"_a,
+                                      "h0"_a,
+                                      "r"_a);
         polygasprops8.def(py::pickle(
-            [](const PolyGasProps<8>& p) -> py::tuple {  // __getstate__
+            [](const PolyGasProps<double, 8>& p) -> py::tuple {  // __getstate__
                 return py::make_tuple(p.cp_coeffs, p.h_coeffs[8], p.r);
             },
-            [](py::tuple t) -> PolyGasProps<8>
+            [](py::tuple t) -> PolyGasProps<double, 8>
             {  // __setstate__
-                PolyGasProps<8> p(t[0].cast<std::array<double, 8>>(), t[1].cast<double>(), t[2].cast<double>());
+                PolyGasProps<double, 8> p(t[0].cast<std::array<double, 8>>(), t[1].cast<double>(), t[2].cast<double>());
                 return p;
             }));
 
         auto polygas8 = py::class_<PyPG8, PyThermo<array_t>, std::shared_ptr<PyPG8>>(m, "PolyGas8");
-        polygas8.def(py::init<const PolyGasProps<8>&>(), "gas_properties"_a);
+        polygas8.def(py::init<const PolyGasProps<double, 8>&>(), "gas_properties"_a);
         polygas8.def(py::pickle(
             [](const PyPG8& g) -> py::tuple {  // __getstate__
                 return py::make_tuple(&g.properties());
             },
             [](py::tuple t) -> PyPG8 {  // __setstate__
-                PyPG8 g(t[0].cast<PolyGasProps<8>>());
+                PyPG8 g(t[0].cast<PolyGasProps<double, 8>>());
                 return g;
             }));
     }


### PR DESCRIPTION
A template parameter on model coefficients:
- allow computation with half or single precision FP (was not possible before due to type promotion)
- fix poor performance when not passing specification of which instruction set to target to the compiler
  - add capability to disable `std::fma`
  - use  `/arch:AVX2` with MSVC, and `-mfma` with  GCC
- fix convergence of `PolyGas<P>::t_f_h` by using a relative residue
- fix benchmarks